### PR TITLE
mongoengine 0.10.2 removed help_text as instance attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-VERSION = '0.4.6.2'
+VERSION = '0.4.6.3'
 
 if __name__ == '__main__':
     setup(

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -726,7 +726,7 @@ class MongoEngineResource(resources.ModelResource):
                 'attribute': name,
                 'unique': f.unique or primary_key,
                 'null': not f.required and not primary_key,
-                'help_text': f.help_text,
+                'help_text': getattr(f, 'help_text', None),
             }
 
             # If field is not required, it does not matter if set default value,


### PR DESCRIPTION
Check https://github.com/MongoEngine/mongoengine/commit/d133913c3dd561e3b0a0002489cad4be9973637f
and
https://github.com/MongoEngine/mongoengine/blob/v0.8.8/mongoengine/base/fields.py#L66-L74

These attributes are defined when the field itself defines it, so it doesn't exists in some cases. The default was None, so use that.
